### PR TITLE
New version of my previous patch proposal

### DIFF
--- a/pyagentx/network.py
+++ b/pyagentx/network.py
@@ -117,8 +117,10 @@ class Network(threading.Thread):
                 for i in range(len(tlist)):
                     try:
                         sok = int(slist[i]) <= int(tlist[i])
+                        if not sok:
+                            break
                         eok = int(elist[i]) >= int(tlist[i])
-                        if not ( sok and eok ):
+                        if not eok:
                             break
                     except IndexError:
                         pass


### PR DESCRIPTION
Fixes incorrect behaviour when navigating a long list of different-length oids from snmpwalk, making oid and endoid to be of different length