### PR TITLE
Enable user to connect to snmp agent with agentx over tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,14 @@ Then you can start and stop it with these commands:
 
 configuration file can be found on the default location "/etc/snmp/snmpd.conf".
 
+
+### To enable AgentX over tcp
+Edit your snmpd.conf file to enable tcp connection
+    agentXSocket    tcp:localhost:705
+
+In your minimal client override the following parameters prior to starting your client
+    
+    # set the socket family, in this case Internet Protocol v4 Addresses
+    pyagentx.SOCKET_FAMILY = socket.AF_INET
+    # set the socket to connect to, in this case localhost on port 705
+    pyagentx.SOCKET_PATH = ('localhost',705)

--- a/pyagentx/__init__.py
+++ b/pyagentx/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import socket
 
 from pyagentx.updater import Updater
 from pyagentx.agent import Agent
@@ -21,6 +22,7 @@ def setup_logging(debug=False):
     logger.addHandler(ch)
 
 SOCKET_PATH = "/var/agentx/master"
+SOCKET_FAMILY = socket.AF_UNIX
 
 AGENTX_EMPTY_PDU            = 1
 AGENTX_OPEN_PDU             = 1

--- a/pyagentx/network.py
+++ b/pyagentx/network.py
@@ -41,7 +41,7 @@ class Network(threading.Thread):
     def _connect(self):
         while True:
             try:
-                self.socket = socket.socket( socket.AF_UNIX, socket.SOCK_STREAM )
+                self.socket = socket.socket(pyagentx.SOCKET_FAMILY, socket.SOCK_STREAM )
                 self.socket.connect(pyagentx.SOCKET_PATH)
                 self.socket.settimeout(0.1)
                 return


### PR DESCRIPTION
This change allow the user of pyagent override the socket family so that they can connect to agentx over tcp if necessary.  By default it's AF_UNIX, the existing socket family.