### PR TITLE
Propagate errors from SetHandler.network_commit()

### DIFF
--- a/pyagentx/network.py
+++ b/pyagentx/network.py
@@ -222,7 +222,11 @@ class Network(threading.Thread):
 
             elif request.type == pyagentx.AGENTX_COMMITSET_PDU:
                 for handler in self._sethandlers.values():
-                    handler.network_commit(request.session_id, request.transaction_id)
+                    try:
+                        handler.network_commit(request.session_id, request.transaction_id)
+                    except:
+                        response.error = pyagentx.ERROR_COMMITFAILED
+                        response.error_index = 1
                 logger.info("Received COMMITSET PDU")
 
             elif request.type == pyagentx.AGENTX_UNDOSET_PDU:

--- a/pyagentx/sethandler.py
+++ b/pyagentx/sethandler.py
@@ -33,11 +33,11 @@ class SetHandler(object):
         tid = "%s_%s" % (session_id, transaction_id)        
         try:
             oid, data = self.transactions[tid]
-            self.commit(oid, data)
-            if tid in self.transactions:
-                del(self.transactions[tid])
-        except:
-            logger.error('CommitSet failed')
+        except KeyError:
+            return
+        self.commit(oid, data)
+        if tid in self.transactions:
+            del(self.transactions[tid])
 
     def network_undo(self, session_id, transaction_id):
         tid = "%s_%s" % (session_id, transaction_id)


### PR DESCRIPTION
SetHandler.network_commit(): Do not silently ignore all the exceptions:
propagate errors from self.commit() (as ERROR_COMMITFAILED) properly.