### PR TITLE
Fix bug in get-next: test start-oid/end-oid separately

### DIFF
--- a/pyagentx/network.py
+++ b/pyagentx/network.py
@@ -117,11 +117,16 @@ class Network(threading.Thread):
                 for i in range(len(tlist)):
                     try:
                         sok = int(slist[i]) <= int(tlist[i])
-                        eok = int(elist[i]) >= int(tlist[i])
-                        if not ( sok and eok ):
-                            break
                     except IndexError:
+                        #sok = True, on most recent successful comparison
                         pass
+                    try:
+                        eok = int(elist[i]) >= int(tlist[i])
+                    except IndexError:
+                        #eok = True, on most recent successful comparison
+                        pass
+                    if not ( sok and eok ):
+                        break
                 if sok and eok:
                     return tmp_oid
             return None # No match!


### PR DESCRIPTION
We had a case where

oid:         '1.3.6.1.2.1.4.24.4.1'
endoid:  '1.3.6.1.2.1.5'

When checking against '1.3.6.1.2.1.4.20.1.1.32.4.1.2', which is below the start-oid's range (note the 20 < 24), it still evaluate as success, making the get-next give a OID that is lesser than the input oid.

The bug seems to be case where the endoid was shorter and this raises a IndexError making the test for (start)oid useless. So, i have separated the tests for soid and eoid. Please consider this change and merge.